### PR TITLE
fix: scraper regex matches new "Last Free Electricity sessions:" heading

### DIFF
--- a/octofree/main.py
+++ b/octofree/main.py
@@ -722,8 +722,10 @@ def main():
             save_last_extracted_sessions(current_sessions)
             logging.debug(f"💾 [STORAGE] Updated last_extracted_sessions.json with {len(current_sessions)} session(s)")
         
-        else:
+        elif html_content is None:
             logging.error("Failed to fetch HTML content.")
+        else:
+            logging.info("ℹ️  No sessions extracted from HTML (page may have no sessions listed yet)")
         
         if single_run:
             break

--- a/octofree/scraper_website.py
+++ b/octofree/scraper_website.py
@@ -65,7 +65,8 @@ def extract_sessions(html_content):
     sessions = []
     session_type = None
     # Try to find "Next Sessions:" first (for multiple)
-    match = re.search(r'Next\s+Sessions?:', html_content, re.IGNORECASE)
+    # Octopus pages vary between "Next Sessions:" and "Next Free Electricity sessions:"
+    match = re.search(r'Next\s+(?:Free\s+Electricity\s+)?Sessions?:', html_content, re.IGNORECASE)
     if match:
         session_type = 'next'
         start_pos = match.end()
@@ -86,8 +87,8 @@ def extract_sessions(html_content):
                 found = re.findall(r'\d+(?:am|pm)?-\d+(?:am|pm)?,\s*\w+\s*\d+(?:st|nd|rd|th)?\s*\w+', part, re.IGNORECASE)
                 sessions.extend(found)
     else:
-        # Check for "Last Session:"
-        match = re.search(r'Last\s+Session:', html_content, re.IGNORECASE)
+        # Check for "Last Session:" or "Last Free Electricity sessions:"
+        match = re.search(r'Last\s+(?:Free\s+Electricity\s+)?Sessions?:', html_content, re.IGNORECASE)
         if match:
             session_type = 'last'
             start_pos = match.end()


### PR DESCRIPTION
## Summary
- Website scraper has been returning 0 sessions because Octopus changed the page heading from `Last Session:` to `⚡️Last Free Electricity sessions:⚡️`. Broaden the regex in `extract_sessions` to accept optional `Free Electricity` and plural `Sessions` for both `Next` and `Last` variants.
- Also clarify a misleading log message: `ERROR: Failed to fetch HTML content.` was firing on every cycle where no sessions were extracted — even when the fetch itself succeeded (96KB of HTML was returned). Split into a real fetch-failure error and an informational log when the page simply has no sessions listed yet.

## Context
Reported from a user's production log showing successful HTML fetches (`length: 96318`) but 0 sessions extracted every cycle, followed by the misleading `Failed to fetch HTML content` error. Verified locally against the current live HTML: the fixed regex correctly extracts `9-10pm, Friday 24th October` and `12-3pm, Saturday 25th October`.

## Test plan
- [x] Manual run of `extract_sessions` against current live HTML from `https://octopus.energy/free-electricity/` returns both scheduled sessions
- [ ] Existing tests still pass
- [ ] Verify in a Docker build against live site

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to distinguish between failed HTML fetches and pages with no available sessions.
  * Enhanced session detection to support additional Octopus website page layout variants, improving extraction reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->